### PR TITLE
Add karma-spec-reporter

### DIFF
--- a/build.conf.js
+++ b/build.conf.js
@@ -126,7 +126,7 @@ function buildConfig(customConfig) {
   cfg.karma = {
     basePath: '.',
     frameworks: ['systemjs', 'jasmine', 'es6-shim'],
-    reporters: ['progress', 'coverage'],
+    reporters: ['spec', 'coverage'],
     preprocessors: {},
     browsers: ['PhantomJS'],
     autoWatch: false,
@@ -162,6 +162,13 @@ function buildConfig(customConfig) {
           'phantomjs-polyfill': getRelativeModulePath('phantomjs-polyfill/bind-polyfill'),
         },
       },
+    },
+    specReporter: {
+      maxLogLines: 5,
+      suppressErrorSummary: true,
+      suppressFailed: false,
+      suppressPassed: true,
+      suppressSkipped: true
     },
   };
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lodash.assign": "4.0.0",
     "phantomjs": "1.9.19",
     "phantomjs-polyfill": "0.0.1",
-    "systemjs-builder": "0.14.15"
+    "systemjs-builder": "0.14.15",
+    "karma-spec-reporter": "0.0.24"
   }
 }


### PR DESCRIPTION
The karma.config.specReporter configuration is set to logs a maximum of 5 lines per test and only shows failed tests.
