### PR TITLE
Feature/html fixtures simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,36 @@
 ## Testing
 
 ### Unit tests
-Hippo-build supports unit testing using Karma and Jasmine. The test files are located using the following file pattern `**/*.spec.js`.
-
+Hippo-build supports unit testing using Karma and Jasmine. The test files are located using the following file pattern
+`**/*.spec.js`.
 #### Loading HTML, CSS and JSON fixtures
 The default Karma setup of hippo-build exposes the [jasmine-jquery](https://github.com/velesin/jasmine-jquery) module
-for handling HTML, CSS and JSON fixtures, as well as provide a set of custom matchers that simplify validating DOM conditions, e.g. `expect($('#id-name')[0]).toBeInDOM()`. 
+for handling HTML, CSS and JSON fixtures, as well as provide a set of custom matchers that simplify validating DOM
+conditions, e.g. `expect($('#id-name')[0]).toBeInDOM()`.
 
-Fixture files should be defined adjacent to the spec files that use them, or at least as close as possible. They follow the same naming convention as the spec files and are named with a `.fixture` suffix, e.g. `cms.login.fixture.html` or `cms.config.fixture.json`. The default value for the fixtures path is set to `base/src/angularjs`. The 'base' part is needed because Karma serves the fixtures files on this path. This value can be changed by setting the configuration parameter `fixturesPath` in the project's `build.conf.js`. Setting this parameter will also change the fixtures path for CSS and JSON files, but these can also be customised using the `styleFixturesPath` and `jsonFixturesPath` parameters.
+Fixture files should be defined adjacent to the spec files that use them, or at least as close as possible. They follow
+the same naming convention as the spec files and are named with a `.fixture` suffix, e.g. `cms.login.fixture.html` or
+`cms.config.fixture.json`. The Karma configuration provided by hippo-build is setup to serve these files on the path
+expected by the jasmine-jquery module. To accomplish this, Karma is instructed to serve fixture files over it's
+HTTP-server by adding a file pattern to the `files` option: `{ pattern: '**/*.fixture.*', included: false }`.
+Second, Karma is instructed to proxy the path `/spec/javascripts/fixtures/` (which is the default fixtures path of
+jasmine-jquery) to `/base/src/angularjs/` (which is a combination of Karma's base path for serving files over HTTP and
+the root folder where hippo-build expects your Angular code to live).
 
-For more control over these paths you can use the following snippet in your spec files:
+This means that if you customise the `files` and/or `proxies` option in your project's Karma configuration, and you need
+to work with fixtures in your tests, you have to replicate these two configuration values:
 ```
-beforeEach(function () {
-  jasmine.getFixtures().fixturesPath = 'base/spec/js/fixtures';
-  jasmine.getStyleFixtures().fixturesPath = 'base/spec/css/fixtures';
-  jasmine.getJSONFixtures().fixturesPath = 'base/spec/json/fixtures';
-});
+proxies: {
+  "/spec/javascripts/fixtures/": "/base/src/angularjs/",
+  "/spec/javascripts/fixtures/json/": "/base/src/angularjs/",
+},
+files: [
+  { pattern: '**/*.fixture.*', included: false },
+]
 ```
+The simplest way is, instead of replacing the `files` and/or `proxies` values, to concatenate your custom values into
+the options provided by hippo-build, e.g. `karma.cfg.files = karma.cfg.files.concat([templates, scripts])`
+
 ##### Example project setup and code
 ```
 |- src
@@ -26,16 +40,32 @@ beforeEach(function () {
     |- main.js
     |- main.spec.js
     |- main.fixture.html
+    |- main.fixture.json
     |- dialogs
       |- dialog.fixture.html
       |- dialog.fixture.css
-      ..  
+      ..
 ```
-In `main.spec.js` you should be able to load fixtures into the DOM with:
+
+In `main.spec.js` you can then load your fixtures with:
 ```
-loadFixtures('main.fixture.html');
+// Load html fixture into the DOM
+jasmine.getFixtures().load('main.fixture.html');
 // from a subfolder
-loadFixtures('dialogs/dialog.fixture.html');
-// load css
-loadStyleFixtures('dialogs/dialog.fixture.css);
+jasmine.getFixtures().load('dialogs/dialog.fixture.html');
+
+// load css fixture into the DOM
+jasmine.getStyleFixtures().load('dialogs/dialog.fixture.css');
+
+// Load JSON fixture object
+var jsonObject = jasmine.getJSONFixtures().load('main.fixture.json');
+```
+
+For more control over the paths you can use the following snippet in your spec files:
+```
+beforeEach(function () {
+  jasmine.getFixtures().fixturesPath = 'base/spec/js/fixtures';
+  jasmine.getStyleFixtures().fixturesPath = 'base/spec/css/fixtures';
+  jasmine.getJSONFixtures().fixturesPath = 'base/spec/json/fixtures';
+});
 ```

--- a/README.md
+++ b/README.md
@@ -3,35 +3,26 @@
 ## Testing
 
 ### Unit tests
-Hippo-build supports unit testing using Karma and Jasmine. The test files are located using the following file pattern
-`**/*.spec.js`.
+Hippo-build supports unit testing using Karma and Jasmine. The test files are located using the following file pattern `**/*.spec.js`.
+
 #### Loading HTML, CSS and JSON fixtures
 The default Karma setup of hippo-build exposes the [jasmine-jquery](https://github.com/velesin/jasmine-jquery) module
-for handling HTML, CSS and JSON fixtures, as well as provide a set of custom matchers that simplify validating DOM
-conditions, e.g. `expect($('#id-name')[0]).toBeInDOM()`.
+for handling HTML, CSS and JSON fixtures, as well as provide a set of custom matchers that simplify validating DOM conditions, e.g. `expect($('#id-name')[0]).toBeInDOM()`.
 
-Fixture files should be defined adjacent to the spec files that use them, or at least as close as possible. They follow
-the same naming convention as the spec files and are named with a `.fixture` suffix, e.g. `cms.login.fixture.html` or
-`cms.config.fixture.json`. The Karma configuration provided by hippo-build is setup to serve these files on the path
-expected by the jasmine-jquery module. To accomplish this, Karma is instructed to serve fixture files over it's
-HTTP-server by adding a file pattern to the `files` option: `{ pattern: '**/*.fixture.*', included: false }`.
-Second, Karma is instructed to proxy the path `/spec/javascripts/fixtures/` (which is the default fixtures path of
-jasmine-jquery) to `/base/src/angularjs/` (which is a combination of Karma's base path for serving files over HTTP and
-the root folder where hippo-build expects your Angular code to live).
+Fixture files should be defined adjacent to the spec files that use them, or at least as close as possible. They follow the same naming convention as the spec files and are named with a `.fixture` suffix, e.g. `cms.login.fixture.html` or `cms.config.fixture.json`. Karma can be instructed to serve fixture files over it's HTTP-server by adding a file pattern  to the `systemjs.includeFiles` array in the project's `karma.conf.js`. The default pattern is saved in `cfg.src.fixtures` and matches  `cfg.srcDir + '**/*.fixture.{html,css,json}'`.
 
-This means that if you customise the `files` and/or `proxies` option in your project's Karma configuration, and you need
-to work with fixtures in your tests, you have to replicate these two configuration values:
+Hippo-build instructs Karma by default to proxy the path `/spec/javascripts/fixtures/` (which is the default fixtures path of jasmine-jquery) to `/base/src/angularjs/`. This is a combination of Karma's base path for serving files over HTTP and the root folder where hippo-build expects your Angular code to live.
+
+When changing the karma options you can customize the proxy path with the following options:
+* override `cfg.srcDir` in your build.conf.js which changes the default proxy path from `/base/src/angularjs` to `/base/[your src dir]/angularjs`
+* override `cfg.karmaFixtureProxyPath` in your build.conf.js directly
+* override `options.proxies` in your karma.conf.js, then you will have to replicate these two configuration values:
 ```
 proxies: {
-  "/spec/javascripts/fixtures/": "/base/src/angularjs/",
-  "/spec/javascripts/fixtures/json/": "/base/src/angularjs/",
+  '/spec/javascripts/fixtures/': '[your proxy path]',
+  '/spec/javascripts/fixtures/json/': '[your proxy path]',
 },
-files: [
-  { pattern: '**/*.fixture.*', included: false },
-]
 ```
-The simplest way is, instead of replacing the `files` and/or `proxies` values, to concatenate your custom values into
-the options provided by hippo-build, e.g. `karma.cfg.files = karma.cfg.files.concat([templates, scripts])`
 
 ##### Example project setup and code
 ```

--- a/build.conf.js
+++ b/build.conf.js
@@ -104,6 +104,7 @@ function buildConfig(customConfig) {
     globals: {
       angular: true,
       $: true,
+      $j: true,
       inject: true,
       module: true,
     },

--- a/build.conf.js
+++ b/build.conf.js
@@ -164,6 +164,13 @@ function buildConfig(customConfig) {
         },
       },
     },
+    proxies: {
+      "/spec/javascripts/fixtures/": "/base/src/angularjs/",
+      "/spec/javascripts/fixtures/json/": "/base/src/angularjs/",
+    },
+    files: [
+      { pattern: '**/*.fixture.*', included: false },
+    ]
   };
 
   cfg.karma.preprocessors[cfg.src.scripts] = ['coverage'];

--- a/build.conf.js
+++ b/build.conf.js
@@ -65,6 +65,7 @@ function buildConfig(customConfig) {
 
   cfg.bowerAssets = [cfg.bowerDir + 'hippo-theme/dist/**/*.{svg,woff,woff2,ttf,eot,png}'];
   cfg.bowerLinks = [cfg.bowerDir + 'hippo-theme/dist/**'];
+  cfg.karmaFixtureProxyPath = '/base/' + cfg.srcDir + 'angularjs/';
 
   /* Gulp Task configuration options */
   cfg.env = {};
@@ -105,6 +106,7 @@ function buildConfig(customConfig) {
     },
     rules: {
       'max-len': 0,
+
       // Needed for ngInject to work with classes :(
       'padded-blocks': 0,
       'no-param-reassign': 0,
@@ -181,12 +183,9 @@ function buildConfig(customConfig) {
       },
     },
     proxies: {
-      "/spec/javascripts/fixtures/": "/base/src/angularjs/",
-      "/spec/javascripts/fixtures/json/": "/base/src/angularjs/",
+      '/spec/javascripts/fixtures/': cfg.karmaFixtureProxyPath,
+      '/spec/javascripts/fixtures/json/': cfg.karmaFixtureProxyPath,
     },
-    files: [
-      { pattern: '**/*.fixture.*', included: false },
-    ]
   };
 
   cfg.karma.preprocessors[cfg.src.scripts] = ['coverage'];


### PR DESCRIPTION
I've simplified the fixturesPath configuration by leveraging karma proxies. By default, hippo-build will proxy the built-in fixturesPath of jasmine-jquery to the root folder of our angular sources, i.e. "/spec/javascripts/fixtures/" -> "/base/src/angularjs/"
To simplify even further, I added a pattern for fixture files to the karma 'files' option. 

Both are described in the README as customization of either option will break this out-of-the-box behavior, albeit a simple fix to get it working again.
